### PR TITLE
fix: wideness of phenotype distribution

### DIFF
--- a/haptools/sim_phenotype.py
+++ b/haptools/sim_phenotype.py
@@ -151,7 +151,7 @@ class PhenoSimulator:
             noise = np.var(pt) * (np.reciprocal(heritability) - 1)
         self.log.info(f"Adding environmental component {noise} for h^2 {heritability}")
         # finally, add everything together to get the simulated phenotypes
-        pt_noise = self.rng.normal(0, noise, size=pt.shape)
+        pt_noise = self.rng.normal(0, np.sqrt(noise), size=pt.shape)
         if self.log.getEffectiveLevel() == DEBUG:
             # if we're in debug mode, compute the pearson correlation and report it
             # but don't do this otherwise to keep things fast


### PR DESCRIPTION
by using the stdev instead of variance in simphenotype and the PhenoSimulator class

apparently, numpy uses the stdev instead of the variance as its scale parameter ([source](https://numpy.org/doc/stable/reference/random/generated/numpy.random.Generator.normal.html#numpy.random.Generator.normal))

A great bug-catch by @gymreklab!