### PR TITLE
docs: update snp2hap example

### DIFF
--- a/docs/api/data.rst
+++ b/docs/api/data.rst
@@ -20,7 +20,7 @@ This module also helps reduce common boilerplate, since users can easily *extend
 
 Data
 ~~~~
-Classes in the ``data`` module inherit from an abstract class called Data, providing some level of standardization across classes within the module. All classes are initialized with the path to the file containing the data and, optionally, a `python Logger <https://docs.python.org/3/howto/logging.html>`_ instance.
+Classes in the ``data`` module inherit from an abstract class called Data, providing some level of standardization across classes within the module.
 
 The abstract class requires that all classes contain methods for...
 
@@ -31,6 +31,14 @@ The abstract class requires that all classes contain methods for...
 
 	from haptools import data
 	data.Data
+
+All classes are initialized with the path to the file containing the data and, optionally, a `python Logger <https://docs.python.org/3/howto/logging.html>`_ instance. All messages are written to the Logger instance. When not provided, Logger instances are initialized with the following settings.
+
+.. code-block:: python
+
+	import logging
+	log = logging.getLogger("haptools command")
+	logging.basicConfig(format="[%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)", level="ERROR")
 
 genotypes.py
 ~~~~~~~~~~~~
@@ -188,7 +196,7 @@ In addition to the ``read()`` and ``load()`` methods, the :class:`GenotypesPLINK
 
 Limiting memory usage
 *********************
-Unfortunately, reading from PGEN files can require a lot of memory, at least initially. (Once the genotypes have been loaded, they are converted down to a lower-memory form.) To determine whether you may be having memory issues, you can place the module in "verbose mode" by providing a `python Logger <https://docs.python.org/3/howto/logging.html>`_ object at the "DEBUG" level when initializing the :class:`GenotypesPLINK` class.
+Unfortunately, reading from PGEN files can require a lot of memory, at least initially. (Once the genotypes have been loaded, they are converted down to a lower-memory form.) To determine whether you may be having memory issues, you may opt to place the module in "verbose mode" by providing a `python Logger <https://docs.python.org/3/howto/logging.html>`_ object at the "DEBUG" level when initializing the :class:`GenotypesPLINK` class. This will release helpful debugging messages.
 
 .. code-block:: python
 

--- a/docs/api/examples.rst
+++ b/docs/api/examples.rst
@@ -64,12 +64,11 @@ Well, you can encode each SNP as a haplotype containing only a single allele. Fo
 
 .. code-block::
 
-    #	orderH	ancestry	beta
+    #	orderH	beta
     #	version	0.1.0
-    #H	ancestry	s	Local ancestry
     #H	beta	.2f	Effect size in linear model
-    H	19	45411941	45411942	rs429358	EUR	0.73
-    H	19	45412079	45412080	rs7412	EUR	0.30
+    H	19	45411941	45411942	rs429358	0.73
+    H	19	45412079	45412080	rs7412	0.30
     V	rs429358	45411941	45411942	rs429358	C
     V	rs7412	45412079	45412080	rs7412	T
 
@@ -97,12 +96,12 @@ You can easily use the :ref:`data API <api-data>` and the :ref:`simphenotype API
     hp.data = {}
 
     for variant in gt.variants:
-    	ID, chrom, pos, alt = variant[["id", "chrom", "pos", "alt"]]
-    	end = pos + len(alt)
+        ID, chrom, pos, alt = variant[["id", "chrom", "pos", "alt"]]
+        end = pos + len(alt)
 
         # create a haplotype line in the .hap file
-        # you should fill out "ancestry" and "beta" with your own values
-        hp.data[ID] = Haplotype(chrom=chrom, start=pos, end=end, id=ID, ancestry="EUR", beta=0.5)
+        # you should fill out "beta" with your own value
+        hp.data[ID] = Haplotype(chrom=chrom, start=pos, end=end, id=ID, beta=0.5)
 
         # create variant lines for each haplotype
         hp.data[ID].variants = (data.Variant(start=pos, end=end, id=ID, allele=alt),)

--- a/docs/commands/ld.rst
+++ b/docs/commands/ld.rst
@@ -56,6 +56,12 @@ Alternatively, we can compute LD between the APOe4 haplotype and all genotypes i
 
 	haptools ld --from-gts -o apoe4.ld APOe4 tests/data/apoe.vcf.gz tests/data/apoe4.hap
 
+You can select a subset of variants (or haplotypes) using the ``--id`` parameter multiple times (or the ``--ids-file`` parameter).
+
+.. code-block:: bash
+
+	haptools ld --from-gts -i rs543363163 -i rs7412 APOe4 tests/data/apoe.vcf.gz tests/data/apoe4.hap
+
 Detailed Usage
 ~~~~~~~~~~~~~~
 

--- a/docs/commands/transform.rst
+++ b/docs/commands/transform.rst
@@ -13,7 +13,7 @@ You may also specify genotypes in PLINK2 PGEN format. Just use the appropriate "
 Ancestry
 ~~~~~~~~
 
-If your ``.hap`` file contains an "ancestry" extra field and your VCF contains a "POP" format field or an accompanying :ref:`.bp file <formats-breakpoints>` (as output by ``simgenotype``), you should specify the ``--ancestry`` flag. This will enable us to match the population labels of each haplotype against those in the genotypes output by ``simgenotype``. See :ref:`this section <formats-haplotypes-extrafields-simphenotype>` of the ``.hap`` format spec for more details.
+If your ``.hap`` file contains an "ancestry" extra field and your VCF contains a "POP" format field or an accompanying :ref:`.bp file <formats-breakpoints>` (as output by ``simgenotype``), you should specify the ``--ancestry`` flag. This will enable us to match the population labels of each haplotype against those in the genotypes output by ``simgenotype``. See :ref:`this section <formats-haplotypes-extrafields-transform>` of the ``.hap`` format spec for more details.
 
 Usage
 ~~~~~

--- a/docs/commands/transform.rst
+++ b/docs/commands/transform.rst
@@ -64,12 +64,6 @@ If your VCF has multi-allelic variants, they must be split into bi-allelic recor
 	bcftools annotate -Ov --set-id +'%CHROM\_%POS\_%REF\_%FIRST_ALT' | \
 	haptools transform -o output.vcf.gz /dev/stdin file.hap
 
-..
-	To include ancestral population labels in the transformation, use the ``--ancestry`` flag:
-
-	.. code-block:: bash
-
-		haptools transform --ancestry tests/data/example.vcf.gz tests/data/simphenotype.hap
 
 Detailed Usage
 ~~~~~~~~~~~~~~

--- a/docs/formats/haplotypes.rst
+++ b/docs/formats/haplotypes.rst
@@ -166,11 +166,41 @@ Additional fields can be appended to the ends of the haplotype and variant lines
 
 .. _formats-haplotypes-extrafields-simphenotype:
 
+transform
+---------
+If you would like to simulate an ancestry-based effect, you should run ``transform`` with an *ancestry* extra field declared in your ``.hap`` file.
+
+You can download an example header with an *ancestry* extra field from `tests/data/simphenotype.hap <https://github.com/cast-genomics/haptools/blob/main/tests/data/simphenotype.hap>`_
+
+.. code-block:: bash
+
+  curl https://raw.githubusercontent.com/cast-genomics/haptools/main/tests/data/simphenotype.hap 2>/dev/null | head -n4
+
+``H`` Haplotype
++++++++++++++++
+
+.. list-table::
+   :widths: 25 25 25 50
+   :header-rows: 1
+
+   * - Column
+     - Field
+     - Type
+     - Description
+   * - 5
+     - Local Ancestry
+     - string
+     - A population code denoting this haplotype's ancestral origins
+
+``V`` Variant
++++++++++++++
+No extra fields are required here.
+
 simphenotype
 ------------
-The *ancestry* and *beta* extra fields should be declared for your ``.hap`` file to be compatible with the ``simphenotype`` subcommand.
+The *beta* extra field should be declared for your ``.hap`` file to be compatible with the ``simphenotype`` subcommand.
 
-You can download an example header for this file from `tests/data/simphenotype.hap <https://github.com/cast-genomics/haptools/blob/main/tests/data/simphenotype.hap>`_
+You can download an example header with a *beta* extra field from `tests/data/simphenotype.hap <https://github.com/cast-genomics/haptools/blob/main/tests/data/simphenotype.hap>`_
 
 .. code-block:: bash
 
@@ -193,10 +223,6 @@ You can download an example header for this file from `tests/data/simphenotype.h
      - Type
      - Description
    * - 5
-     - Local Ancestry
-     - string
-     - A population code denoting this haplotype's ancestral origins
-   * - 6
      - Effect Size
      - float
      - The effect size of this haplotype; for use in ``simphenotype``

--- a/docs/formats/haplotypes.rst
+++ b/docs/formats/haplotypes.rst
@@ -160,6 +160,26 @@ We encourage you to sort, bgzip compress, and index your ``.hap`` file whenever 
 
 In order to properly index the file, the set of IDs in the haplotype lines must be distinct from the set of chromosome names. This is a best practice in unindexed ``.hap`` files but a requirement for indexed ones. In addition, you must sort on the first field (ie the line type symbol) in addition to the latter three.
 
+Querying an indexed file
+~~~~~~~~~~~~~~~~~~~~~~~~
+You can query an indexed ``.hap`` file on both the haplotype and variant levels with the following syntax.
+
+.. code-block:: bash
+
+  tabix file.hap.gz REGION
+
+For example, to extract all haplotypes between positions 100 and 200 on chromosome ``chr19``:
+
+.. code-block:: bash
+
+  tabix file.hap.gz chr19:100-200
+
+Or to get all alleles between positions 100 and 200 on the haplotype with ID ``hap1``:
+
+.. code-block:: bash
+
+  tabix file.hap.gz hap1:100-200
+
 Extra fields
 ~~~~~~~~~~~~
 Additional fields can be appended to the ends of the haplotype and variant lines as long as they are declared in the header.

--- a/docs/formats/haplotypes.rst
+++ b/docs/formats/haplotypes.rst
@@ -164,7 +164,7 @@ Extra fields
 ~~~~~~~~~~~~
 Additional fields can be appended to the ends of the haplotype and variant lines as long as they are declared in the header.
 
-.. _formats-haplotypes-extrafields-simphenotype:
+.. _formats-haplotypes-extrafields-transform:
 
 transform
 ---------
@@ -195,6 +195,8 @@ You can download an example header with an *ancestry* extra field from `tests/da
 ``V`` Variant
 +++++++++++++
 No extra fields are required here.
+
+.. _formats-haplotypes-extrafields-simphenotype:
 
 simphenotype
 ------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,11 +8,12 @@ Haptools is a collection of tools for simulating and analyzing genotypes and phe
 Installation
 ~~~~~~~~~~~~
 .. note::
-   To reduce the likelihood of errors when installing, we recommend installing ``haptools`` within a new conda environment with a recent version of pip:
+   To reduce the likelihood of errors, we recommend installing ``haptools`` within a new conda environment using a recent version of pip:
 
    .. code-block:: bash
 
-      conda create -n haptools -c conda-forge 'pip>=22.2.2'
+      conda create -y -n haptools -c conda-forge 'pip>=22.2.2'
+      conda activate haptools
 
 We have not officially published ``haptools`` yet, but in the meantime, you can install it directly from our Github repository.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,9 @@ Summary of Commands
 * `haptools ld </commands/ld>`_: Compute Pearson's correlation coefficient between a target haplotype and a set of haplotypes.
 
 Outputs produced by these utilities are compatible with each other.
-For example ``haptools simgenotype`` outputs a VCF file with local ancestry information annotated for each variant. The output VCF file can be used as input to ``haptools transform`` and ``haptools simphenotype`` to simulate phenotype information. ``haptools simgenotype`` also outputs a list of local ancestry breakpoints which can be visualized using ``haptools karyogram``.
+For example ``haptools simgenotype`` outputs a VCF file with local ancestry information annotated for each variant.
+The VCF and breakpoints file output by ``haptools simgenotype`` can be used as input to ``haptools transform``, which is then used by ``haptools simphenotype`` to simulate phenotypes for a list of haplotypes.
+The local ancestry breakpoints from ``haptools simgenotype`` can also be visualized using ``haptools karyogram``.
 
 Contributing
 ~~~~~~~~~~~~


### PR DESCRIPTION
resolves #118

This PR fixes some errors in the snp2hap example within the API docs. In addition, it adds a description of the ancestry extra field to a separate section of the Haplotypes documentation.

It also describes how to use the Logger module in the API docs and explains how to query from a tabix-indexed hap file.