### PR TITLE
dep: require <3.11 to resolve pysam install error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/cast-genomics/haptools"
 documentation = "https://haptools.readthedocs.io"
 
 [tool.poetry.dependencies]
-python = ">=3.7"
+python = ">=3.7,<3.11"
 click = ">=8.0.3"
 pysam = ">=0.19.0"
 cyvcf2 = ">=0.30.14"


### PR DESCRIPTION
agh! our installation is broken!

pysam doesn't have support for 3.11 yet, and we depend on pysam
so if the user tries to install haptools with python 3.11, pip will install pysam from its sdist instead of its wheel
...and sdists always cause problems