### PR TITLE
refactor: `data.Phenotypes` samples parameter to be of type set

### DIFF
--- a/docs/api/data.rst
+++ b/docs/api/data.rst
@@ -414,7 +414,7 @@ Both the ``load()`` and ``read()`` methods support the ``samples`` parameter tha
 .. code-block:: python
 
 	phenotypes = data.Phenotypes('tests/data/simple.pheno')
-	phenotypes.read(samples=["HG00097", "HG00099"])
+	phenotypes.read(samples={"HG00097", "HG00099"})
 
 Iterating over a file
 *********************
@@ -433,7 +433,7 @@ You'll have to call ``__iter()__`` manually if you want to specify any function 
 .. code-block:: python
 
 	phenotypes = data.Phenotypes('tests/data/simple.pheno')
-	for line in phenotypes.__iter__(samples=["HG00097", "HG00099"]):
+	for line in phenotypes.__iter__(samples={"HG00097", "HG00099"}):
 	    print(line)
 
 Writing a file

--- a/haptools/data/phenotypes.py
+++ b/haptools/data/phenotypes.py
@@ -42,7 +42,7 @@ class Phenotypes(Data):
 
     @classmethod
     def load(
-        cls: Phenotypes, fname: Path | str, samples: list[str] = None
+        cls: Phenotypes, fname: Path | str, samples: set[str] = None
     ) -> Phenotypes:
         """
         Load phenotypes from a pheno file
@@ -53,7 +53,7 @@ class Phenotypes(Data):
         ----------
         fname
             See documentation for :py:attr:`~.Data.fname`
-        samples : list[str], optional
+        samples : set[str], optional
             See documentation for :py:meth:`~.Data.Phenotypes.read`
 
         Returns
@@ -66,13 +66,13 @@ class Phenotypes(Data):
         phenotypes.standardize()
         return phenotypes
 
-    def read(self, samples: list[str] = None):
+    def read(self, samples: set[str] = None):
         """
         Read phenotypes from a pheno file into a numpy matrix stored in :py:attr:`~.Penotypes.data`
 
         Parameters
         ----------
-        samples : list[str], optional
+        samples : set[str], optional
             A subset of the samples from which to extract phenotypes
 
             Defaults to loading phenotypes from all samples
@@ -128,13 +128,13 @@ class Phenotypes(Data):
                     )
         phens.close()
 
-    def __iter__(self, samples: list[str] = None) -> Iterable[namedtuple]:
+    def __iter__(self, samples: set[str] = None) -> Iterable[namedtuple]:
         """
         Read phenotypes from a pheno line by line without storing anything
 
         Parameters
         ----------
-        samples : list[str], optional
+        samples : set[str], optional
             A subset of the samples from which to extract phenotypes
 
             Defaults to loading phenotypes from all samples
@@ -162,7 +162,6 @@ class Phenotypes(Data):
                 " and should be named '#IID' in the header line"
             )
         self.names = tuple(header[1:])
-        samples = set(samples) if samples else None
         # call another function to force the lines above to be run immediately
         # see https://stackoverflow.com/a/36726497
         return self._iterate(phens, phen_text, samples)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -438,7 +438,7 @@ class TestPhenotypes:
 
         # can we load the data from the phenotype file?
         phens = Phenotypes(DATADIR.joinpath("simple.pheno"))
-        phens.read(samples=samples)
+        phens.read(samples=set(samples))
         np.testing.assert_allclose(phens.data, expected)
         assert phens.samples == tuple(samples)
 
@@ -503,7 +503,7 @@ class TestCovariates:
         return expected
 
     def _get_fake_covariates(self):
-        gts = Phenotypes(fname=None)
+        gts = Covariates(fname=None)
         gts.data = self._get_expected_covariates()
         gts.samples = ("HG00096", "HG00097", "HG00099", "HG00100", "HG00101")
         gts.names = ("sex", "age")
@@ -551,7 +551,7 @@ class TestCovariates:
 
         # can we load the data from the covariate file?
         covars = Covariates(DATADIR.joinpath("simple.covar"))
-        covars.read(samples=samples)
+        covars.read(samples=set(samples))
         np.testing.assert_allclose(covars.data, expected)
         assert covars.samples == tuple(samples)
 

--- a/tests/test_simphenotype.py
+++ b/tests/test_simphenotype.py
@@ -111,6 +111,7 @@ class TestSimPhenotype:
         assert phens.samples == expected.samples
         assert phens.names[0] == expected.names[0]
 
+    @pytest.mark.filterwarnings('ignore::RuntimeWarning')
     def test_one_hap_zero_noise_all_same_nonzero_heritability(self):
         gts = self._get_fake_gens()
         hps = self._get_fake_haps()

--- a/tests/test_simphenotype.py
+++ b/tests/test_simphenotype.py
@@ -111,7 +111,7 @@ class TestSimPhenotype:
         assert phens.samples == expected.samples
         assert phens.names[0] == expected.names[0]
 
-    @pytest.mark.filterwarnings('ignore::RuntimeWarning')
+    @pytest.mark.filterwarnings("ignore::RuntimeWarning")
     def test_one_hap_zero_noise_all_same_nonzero_heritability(self):
         gts = self._get_fake_gens()
         hps = self._get_fake_haps()


### PR DESCRIPTION
Changes the type of the samples parameter in the `data.Phenotypes.read` and `data.Phenotypes.__iter__` methods to a set

This is just a bit more efficient. Instead of converting the argument to a set internally, we just rely upon it being a set to begin with.