### PR TITLE
docs: better showcase example files and their locations in `simgenotype`

### DIFF
--- a/docs/commands/simgenotype.rst
+++ b/docs/commands/simgenotype.rst
@@ -73,6 +73,11 @@ If speed is important, it's generally faster to use PGEN files than VCFs.
   --pop_field \
   --out tests/data/example_simgenotype.pgen
 
+Example model files found in `haptools/example-files/models/ <https://github.com/CAST-genomics/haptools/tree/main/example-files/models>`_ and `haptools/tests/data/ <https://github.com/CAST-genomics/haptools/tree/main/tests/data>`_.
+Example map files found in `haptools/tests/data/map/ <https://github.com/CAST-genomics/haptools/tree/main/tests/data/map>`_.
+Example ref_vcf file can be found `haptools/tests/data/outvcf_test.vcf <https://github.com/CAST-genomics/haptools/blob/main/tests/data/outvcf_test.vcf>`_.
+Example sample_info files found in `haptools/example-files/ <https://github.com/CAST-genomics/haptools/tree/main/example-files>`_ and `haptools/tests/data/outvcf_info.tab <https://github.com/CAST-genomics/haptools/blob/main/tests/data/outvcf_info.tab>`_.
+
 
 Detailed Usage
 ~~~~~~~~~~~~~~

--- a/docs/formats/models.rst
+++ b/docs/formats/models.rst
@@ -40,3 +40,8 @@ Example pulse event model.dat file
   4    1         0      0
 
 Simulating 40 samples for 4 generations in this case implies the first generation has population freqs ``Admixed=0, CEU=0.2, YRI=0.8`` the second generation is purely admixed, the third has an event where a pure CEU population is introduced again at freqs ``Admixed=0.5, CEU=0.5, YRI=0`` and finally we end with pure admixture. 
+
+More Example files
+------------------
+We have generated example model files that simulate current population structures within different populations in America as well as the Caribbean that can be found in the haptools repository here: `haptools/example-files/models/ <https://github.com/CAST-genomics/haptools/tree/main/example-files/models>`_
+There are additional example model files that can be found in the haptools repository under `haptools/tests/data/ <https://github.com/CAST-genomics/haptools/tree/main/tests/data>`_

--- a/haptools/__main__.py
+++ b/haptools/__main__.py
@@ -90,8 +90,8 @@ def karyogram(bp, sample, out, title, centromeres, colors, verbosity):
     required=True,
     help=(
         "Admixture model in .dat format. See File Formats under simgenotype in the "
-        "docs for complete info.",
-    )
+        "docs for complete info."
+    ),
 )
 @click.option(
     "--mapdir",

--- a/haptools/__main__.py
+++ b/haptools/__main__.py
@@ -88,7 +88,7 @@ def karyogram(bp, sample, out, title, centromeres, colors, verbosity):
     "--model",
     type=str,
     required=True,
-    help="Admixture model in .dat format. See docs for info.",
+    help="Admixture model in .dat format. See File Format for complete info.",
 )
 @click.option(
     "--mapdir",

--- a/haptools/__main__.py
+++ b/haptools/__main__.py
@@ -88,7 +88,10 @@ def karyogram(bp, sample, out, title, centromeres, colors, verbosity):
     "--model",
     type=str,
     required=True,
-    help="Admixture model in .dat format. See File Format for complete info.",
+    help=(
+        "Admixture model in .dat format. See File Formats under simgenotype in the "
+        "docs for complete info.",
+    )
 )
 @click.option(
     "--mapdir",


### PR DESCRIPTION
Updated the simgenotype docs page, models doc page, and the click documentation to better lead people where they can find example files for the input formats for simgenotype.