### PR TITLE
build: bump the version of poetry used in our CD pipeline

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,5 +1,5 @@
-pip==22.2.2
+pip==23.0
 nox==2022.8.7
 nox-poetry==1.0.1
-poetry==1.1.14
+poetry==1.3.2
 virtualenv==20.16.6

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -65,7 +65,10 @@ class TestGenotypes:
         assert len(caplog.records) > 0 and caplog.records[0].levelname == "WARNING"
 
         # force one of the samples to have a missing GT and check that we get an error
+        # we convert to an int8 and then convert back
+        gts.data = gts.data.astype(np.int8)
         gts.data[1, 1, 1] = -1
+        gts.data = gts.data.astype(np.uint8)
         with pytest.raises(ValueError) as info:
             gts.check_missing()
         assert (


### PR DESCRIPTION
Closes #173 

Second attempt at resolving the build issue from https://github.com/CAST-genomics/haptools/commit/6eac7ef2e8bc81f1cdedc98b446c03c2641b52cf. This time, we're taking a less destructive approach by only upgrading poetry in the build pipeline instead of bumping it completely. The benefit of this is that we'll be able to keep python 3.7 support for a little longer instead of doing #173 