### PR TITLE
fix: add poetry readme to fix long_description when publishing to pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license = "MIT"
 repository = "https://github.com/cast-genomics/haptools"
 homepage = "https://github.com/cast-genomics/haptools"
 documentation = "https://haptools.readthedocs.io"
+readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.7,<3.11"


### PR DESCRIPTION
To fix the broken build in https://github.com/CAST-genomics/haptools/commit/541828b88473d0618d757a4d30ea96000e436e21, we need to declare a README in our pyproject.toml