### PR TITLE
fix: NoneType error in `Haplotypes.__iter__`

### DIFF
--- a/docs/api/data.rst
+++ b/docs/api/data.rst
@@ -137,7 +137,7 @@ Additionally, you can use the ``check_maf()`` method after checking for missing 
 	genotypes.read()
 	genotypes.check_missing()
 	genotypes.check_biallelic()
-	genotypes.check_maf(threshold=0)
+	genotypes.check_maf(threshold=0.0) # replace 0 with your desired threshold
 	genotypes.check_phase()
 
 Subsetting

--- a/docs/api/data.rst
+++ b/docs/api/data.rst
@@ -137,7 +137,7 @@ Additionally, you can use the ``check_maf()`` method after checking for missing 
 	genotypes.read()
 	genotypes.check_missing()
 	genotypes.check_biallelic()
-	genotypes.check_maf(threshold=0.05)
+	genotypes.check_maf(threshold=0)
 	genotypes.check_phase()
 
 Subsetting
@@ -258,7 +258,7 @@ The ``load()`` method initializes an instance of the :class:`Haplotypes` class a
 
 .. code-block:: python
 
-	haplotypes = data.Haplotypes('tests/data/basic.hap', Haplotype, Variant)
+	haplotypes = data.Haplotypes('tests/data/basic.hap', data.Haplotype, data.Variant)
 	haplotypes.read()
 	haplotypes.data # returns a dictionary of Haplotype objects
 
@@ -266,8 +266,8 @@ Both the ``load()`` and ``read()`` methods support `region` and `haplotypes` par
 
 .. code-block:: python
 
-	haplotypes = data.Haplotypes('tests/data/basic.hap.gz', Haplotype, Variant)
-	haplotypes.read(region='chr21:26928472-26941960', haplotypes=["chr21.q.3365*10"])
+	haplotypes = data.Haplotypes('tests/data/basic.hap.gz', data.Haplotype, data.Variant)
+	haplotypes.read(region='21:26928472-26941960', haplotypes=["chr21.q.3365*10"])
 
 The file must be indexed if you wish to use these parameters, since in that case, the ``read()`` method can take advantage of the indexing to parse the file a bit faster. Otherwise, if the file isn't indexed, the ``read()`` method will assume the file could be unsorted and simply reads each line one-by-one. Although I haven't tested it yet, streams like stdin should be supported by this case.
 
@@ -287,7 +287,7 @@ You'll have to call ``__iter()__`` manually if you want to specify any function 
 
 .. code-block:: python
 
-	haplotypes = data.Haplotypes('tests/data/basic.hap')
+	haplotypes = data.Haplotypes('tests/data/basic.hap.gz')
 	for line in haplotypes.__iter__(region='21:26928472-26941960', haplotypes={"chr21.q.3365*1"}):
 	    print(line)
 
@@ -299,8 +299,8 @@ To write to a **.hap** file, you must first initialize a :class:`Haplotypes` obj
 
 	haplotypes = data.Haplotypes('tests/data/example-write.hap')
 	haplotypes.data = {}
-	haplotypes.data['H1'] = Haplotype(chrom='chr1', start=0, end=10, id='H1')
-	haplotypes.data['H1'].variants = (Variant(start=0, end=1, id='rs123', allele='A'),)
+	haplotypes.data['H1'] = data.Haplotype(chrom='chr1', start=0, end=10, id='H1')
+	haplotypes.data['H1'].variants = (data.Variant(start=0, end=1, id='rs123', allele='A'),)
 	haplotypes.write()
 
 Obtaining haplotype "genotypes"
@@ -341,7 +341,7 @@ To read "extra" fields from a **.hap** file, one need only *extend* (sub-class) 
             ),
         )
 
-    haps = Haplotypes("file.hap", haplotype=CustomHaplotype)
+    haps = data.Haplotypes("file.hap", haplotype=CustomHaplotype)
     haps.read()
     haps.write()
 
@@ -372,7 +372,7 @@ To read "extra" fields from a **.hap** file, one need only *extend* (sub-class) 
             ),
         )
 
-    haps = Haplotypes("file.hap", variant=CustomVariant)
+    haps = data.Haplotypes("file.hap", variant=CustomVariant)
     haps.read()
     haps.write()
 

--- a/docs/api/haptools.rst
+++ b/docs/api/haptools.rst
@@ -34,6 +34,7 @@ haptools.data.genotypes module
    :members:
    :undoc-members:
    :show-inheritance:
+   :special-members: __iter__
 
 .. _api-haptools-data-phenotypes:
 
@@ -44,6 +45,7 @@ haptools.data.phenotypes module
    :members:
    :undoc-members:
    :show-inheritance:
+   :special-members: __iter__
 
 .. _api-haptools-data-covariates:
 
@@ -54,6 +56,7 @@ haptools.data.covariates module
    :members:
    :undoc-members:
    :show-inheritance:
+   :special-members: __iter__
 
 .. _api-haptools-data-haplotypes:
 
@@ -64,6 +67,7 @@ haptools.data.haplotypes module
    :members:
    :undoc-members:
    :show-inheritance:
+   :special-members: __iter__
 
 .. _api-haptools-data-breakpoints:
 
@@ -92,6 +96,7 @@ haptools.sim_phenotype module
    :members:
    :undoc-members:
    :show-inheritance:
+   :special-members: __iter__
 
 haptools.karyogram module
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/haptools/data/haplotypes.py
+++ b/haptools/data/haplotypes.py
@@ -558,6 +558,7 @@ class Haplotypes(Data):
     Examples
     --------
     Parsing a basic .hap file without any extra fields is simple:
+
     >>> haplotypes = Haplotypes.load('tests/data/basic.hap')
     >>> haps = haplotypes.data # a dictionary of Haplotype objects
 
@@ -565,6 +566,7 @@ class Haplotypes(Data):
     manually. You'll also need to create Haplotype and Variant subclasses that support
     the extra fields and then specify the names of the classes when you initialize the
     Haplotypes object:
+
     >>> haplotypes = Haplotypes('tests/data/simphenotype.hap', HaptoolsHaplotype)
     >>> haplotypes.read()
     >>> haps = haplotypes.data # a dictionary of Haplotype objects
@@ -858,6 +860,11 @@ class Haplotypes(Data):
         """
         Read haplotypes from a .hap file line by line without storing anything
 
+        .. note::
+            The elements output by ``__iter__()`` are not guaranteed to be in any
+            particular order except that variants of a haplotype will never appear
+            before the haplotype, itself.
+
         Parameters
         ----------
         region: str, optional
@@ -1043,6 +1050,7 @@ class Haplotypes(Data):
         --------
         To write to a .hap file, you must first initialize a Haplotypes object and then
         fill out the data property:
+
         >>> haplotypes = Haplotypes('tests/data/basic.hap')
         >>> haplotypes.data = {'H1': Haplotype('chr1', 0, 10, 'H1')}
         >>> haplotypes.write()

--- a/haptools/data/haplotypes.py
+++ b/haptools/data/haplotypes.py
@@ -854,6 +854,64 @@ class Haplotypes(Data):
                     types[symbol][extra] = None
         return types
 
+    def _iter_haps(self, haps_file: TabixFile, line_type: tuple[Extra], region: str = None, haplotypes: set[str] = None) -> Iterator[Haplotype]:
+        """
+        Read haplotype lines from a .hap file line by line
+
+        This is a helper function for :py:meth:`~.Haplotypes.__iter__`
+
+        Parameters
+        ----------
+        haps_file: TabixFile
+            The indexed .hap file from which to read haplotype lines
+        line_type: tuple[Extra]
+            The set of declared extra field names for haplotype lines
+        region: str, optional
+            See documentation for :py:meth:`~.Haplotypes.__iter__`
+        haplotypes: set[str], optional
+            See documentation for :py:meth:`~.Haplotypes.__iter__`
+
+        Yields
+        ------
+        Iterator[Haplotype]
+            An iterator over each Haplotype line in the file
+        """
+        if region:
+            region_str = region
+            # split region into tuple
+            region = region.split(":", maxsplit=1)
+            if len(region) > 1:
+                region = [region[0],] + list(map(int, region[1].split("-")))
+                # adjust for 0-based vs 1-based indexing of region coordinates
+                region[1] -= 1
+            # fetch region
+            # we already know that each line will start with an H, so we don't
+            # need to check that
+            for line in haps_file.fetch(region=region_str, multiple_iterators=True):
+                hap = self.types["H"].from_hap_spec(line, types=line_type)
+                if haplotypes is not None:
+                    if hap.id not in haplotypes:
+                        continue
+                # also exclude haplotypes that overlap but don't fit perfectly
+                if len(region) >= 3 and hap.start < region[1] or hap.end > region[2]:
+                    continue
+                elif len(region) == 2 and hap.start < region[1]:
+                    continue
+                yield hap
+        else:
+            for line in haps_file.fetch(multiple_iterators=True):
+                # we only want lines that start with an H
+                line_type = self._line_type(line)
+                if line_type == "H":
+                    hap = self.types["H"].from_hap_spec(line, types=line_type)
+                    if hap.id in haplotypes:
+                        yield hap
+                elif line_type > "H":
+                    # if we've already passed all of the H's, we can just exit
+                    # We assume the file has been sorted so that all of the H lines
+                    # come before the V lines
+                    break
+
     def __iter__(
         self, region: str = None, haplotypes: set[str] = None
     ) -> Iterator[Variant | Haplotype]:
@@ -890,11 +948,13 @@ class Haplotypes(Data):
         If you're worried that the contents of the .hap file will be large, you may
         opt to parse the file line-by-line instead of loading it all into memory at
         once. In cases like these, you can use the __iter__() method in a for-loop:
+
         >>> haplotypes = Haplotypes('tests/data/basic.hap')
         >>> for line in haplotypes:
         ...     print(line)
 
         Call the function manually to pass it the region or haplotypes params:
+
         >>> haplotypes = Haplotypes('tests/data/basic.hap.gz')
         >>> for line in haplotypes.__iter__(
         ...    region='21:26928472-26941960', haplotypes={"chr21.q.3365*1"}
@@ -913,50 +973,18 @@ class Haplotypes(Data):
             haps_file = TabixFile(str(self.fname))
             metas, extras = self.check_header(list(haps_file.header))
             types = self._get_field_types(extras, metas.get("order"))
-            if region:
-                region_positions = region.split(":", maxsplit=1)[1]
-                region_start, region_end = tuple(map(int, region_positions.split("-")))
-                # fetch region
-                # we already know that each line will start with an H, so we don't
-                # need to check that
-                for line in haps_file.fetch(region):
-                    hap = self.types["H"].from_hap_spec(line, types=types["H"])
-                    if haplotypes is not None:
-                        if hap.id not in haplotypes:
-                            continue
-                    # also exclude haplotypes that overlap but don't fit perfectly
-                    if hap.start < region_start or hap.end > region_end:
-                        continue
-                    yield hap
-            else:
-                for line in haps_file.fetch():
-                    # we only want lines that start with an H
-                    line_type = self._line_type(line)
-                    if line_type == "H":
-                        hap = self.types["H"].from_hap_spec(line, types=types["H"])
-                        if hap.id in haplotypes:
-                            yield hap
-                    elif line_type > "H":
-                        # if we've already passed all of the H's, we can just exit
-                        # We assume the file has been sorted so that all of the H lines
-                        # come before the V lines
-                        break
             # query for the variants of each haplotype
-            for hap_id in self.data:
-                # exclude variants outside the desired region
-                hap_region = hap_id
-                if region:
-                    hap_region = hap_id
+            for hap in self._iter_haps(haps_file, types["H"], region, haplotypes):
                 # fetch region
                 # we already know that each line will start with a V, so we don't
                 # need to check that
-                for line in haps_file.fetch(hap_region):
+                for line in haps_file.fetch(reference=hap.id, multiple_iterators=True):
                     line_type = self._line_type(line)
                     if line_type == "V":
                         var = self.types["V"].from_hap_spec(line, types=types["V"])[1]
                         # add the haplotype, since otherwise, the user won't know
                         # which haplotype this variant belongs to
-                        var.hap = hap_id
+                        var.hap = hap.id
                         yield var
                     else:
                         self.log.warning(

--- a/haptools/data/phenotypes.py
+++ b/haptools/data/phenotypes.py
@@ -140,7 +140,7 @@ class Phenotypes(Data):
             Defaults to loading phenotypes from all samples
 
         Returns
-        ------
+        -------
         Iterable[namedtuple]
             See documentation for :py:meth:`~.Phenotypes._iterate`
         """

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -770,13 +770,13 @@ class TestHaplotypes:
         assert all(line in exp_single_hap2 for line in haps_iter)
 
         # also, try adding the hap ID
-        for exp_hap, line in zip(exp_single_hap, haps.__iter__(
-            region="21:26928472-26941960", haplotypes={"chr21.q.3365*1"}
-        )):
+        i = haps.__iter__(region="21:26928472-26941960", haplotypes={"chr21.q.3365*1"})
+        for exp_hap, line in zip(exp_single_hap, i):
             assert exp_hap == line
 
         # also, try adding the hap ID
-        for exp_hap, line in zip(exp_single_hap, haps.__iter__(haplotypes={"chr21.q.3365*1"})):
+        haps_iter = haps.__iter__(haplotypes={"chr21.q.3365*1"})
+        for exp_hap, line in zip(exp_single_hap, haps_iter):
             assert exp_hap == line
 
     def test_read_subset(self):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -729,6 +729,38 @@ class TestHaplotypes:
         haps = Haplotypes.load(DATADIR.joinpath("basic.hap.gz"))
         assert expected == haps.data
 
+    def test_iterate(self):
+        expected_full = self._basic_haps()
+        expected_single_hap = expected_full["chr21.q.3365*1"]
+        expected = [
+            hap for hap in expected_full.values()
+        ]
+        for hap in expected:
+            hap.variants = ()
+        expected += [
+            variant for hap in expected_full.values() for variant in hap.variants
+        ]
+
+        # can we load this data from the hap file?
+        haps = Haplotypes(DATADIR.joinpath("basic.hap"))
+        for exp_hap, line in zip(expected, haps):
+            assert exp_hap == line
+
+        exp_sort = expected.copy()
+        exp_sort[1], exp_sort[2] = exp_sort[2], exp_sort[1]
+
+        # also check whether it works when we pass function params
+        haps = Haplotypes(DATADIR.joinpath("basic.hap.gz"))
+        for exp_hap, line in zip(exp_sort, haps.__iter__(region='21:26928472-26941960')):
+            assert exp_hap == line
+
+        haps = Haplotypes(DATADIR.joinpath("basic.hap.gz"))
+        count = 0
+        for line in haps.__iter__(region='21:26928472-26941960', haplotypes={"chr21.q.3365*1"}):
+            count += 1
+            assert line == expected_single_hap
+        assert count == 1
+
     def test_read_subset(self):
         expected = {}
         expected["chr21.q.3365*1"] = self._basic_haps()["chr21.q.3365*1"]


### PR DESCRIPTION
Fixes a bug in `Haplotypes.__iter__()` and some issues with some of the example docs for the `Haplotype` class in the API section.

This PR also adds a new method `test_iterate` to the `TestHaplotypes` class in our test suite. It includes comprehensive testing for all kinds of different edge-cases in `Hapltypes.__iter__()`