### PR TITLE
fix: precision of phenotypes written to pheno file

### DIFF
--- a/haptools/data/phenotypes.py
+++ b/haptools/data/phenotypes.py
@@ -192,15 +192,17 @@ class Phenotypes(Data):
         # now we can finally write the file
         with self.hook_compressed(self.fname, mode="w") as phens:
             phens.write("#IID\t" + "\t".join(names) + "\n")
-            formatter = {"float_kind": lambda x: "%.2f" % x}
             for samp, phen in zip(self.samples, self.data):
                 line = np.array2string(
                     phen,
+                    sign=" ",
+                    legacy=False,
                     separator="\t",
-                    formatter=formatter,
-                    max_line_width=np.inf,
                     threshold=np.inf,
                     edgeitems=np.inf,
+                    floatmode="unique",
+                    suppress_small=False,
+                    max_line_width=np.inf,
                 )[1:-1]
                 phens.write(f"{samp}\t" + line + "\n")
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -585,7 +585,7 @@ class TestPhenotypes:
         # now, let's load the data and check that it's what we wrote
         result = Phenotypes(expected_phen.fname)
         result.read()
-        np.testing.assert_allclose(expected_phen.data, result.data)
+        np.testing.assert_allclose(expected_phen.data, result.data, rtol=0, atol=0)
         assert expected_phen.names == result.names
         assert expected_phen.samples == result.samples
 
@@ -597,7 +597,7 @@ class TestPhenotypes:
         # now, let's load the data and check that it's what we wrote
         result = Phenotypes(expected_phen.fname)
         result.read()
-        np.testing.assert_allclose(expected_phen.data, result.data)
+        np.testing.assert_allclose(expected_phen.data, result.data, rtol=0, atol=0)
         assert expected_phen.names == result.names
         assert expected_phen.samples == result.samples
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -589,8 +589,20 @@ class TestPhenotypes:
         assert expected_phen.names == result.names
         assert expected_phen.samples == result.samples
 
+        # try to standardize the data and see if it's still close
+        # to validate that our code can handle phenotypes with arbitrary precision
+        expected_phen.standardize()
+        expected_phen.write()
+
+        # now, let's load the data and check that it's what we wrote
+        result = Phenotypes(expected_phen.fname)
+        result.read()
+        np.testing.assert_allclose(expected_phen.data, result.data)
+        assert expected_phen.names == result.names
+        assert expected_phen.samples == result.samples
+
         # let's clean up after ourselves and delete the file
-        os.remove(str(expected_phen.fname))
+        expected_phen.fname.unlink()
 
     def test_append_phenotype(self):
         expected1 = self._get_fake_phenotypes()


### PR DESCRIPTION
This fixes a serious issue with the way that haptools writes phenotypes to `.pheno` files. Up until now, it would sometimes drop the sign of any negative phenotype values and leave only two units of precision past the decimal point for floating points. This new code should make the phenotype values much more precise and fix the sign issue.

Users of `simphenotype` should rerun any analyses with this new code. Shoutout to @LiterallyUniqueLogin for finding this bug and helping me debug it! I've been banging my head for days.