### PR TITLE
fix: Added logic to finding all coord files

### DIFF
--- a/haptools/sim_genotype.py
+++ b/haptools/sim_genotype.py
@@ -872,11 +872,11 @@ def validate_params(model, mapdir, chroms, popsize, invcf, sample_info, no_repla
             if re.search(r'(?<=chr)(X|\d+)', coord_file) and \
                re.search(r'(?<=chr)(X|\d+)', coord_file).group() in chroms]
     except:
-        raise Exception("No valid coordinate files found. Must contain chr{1-22,X} in the file name "
+        raise Exception("No valid coordinate files found. Must contain chr{1-22,X} in the file name"
                         " and end in .map")
     
     if not all_coord_files:
-        raise Exception("No valid coordinate files found. Must contain chr{1-22,X} in the file name "
+        raise Exception("No valid coordinate files found. Must contain chr{1-22,X} in the file name"
                         " and end in .map")
     
     # validate popsize

--- a/haptools/sim_genotype.py
+++ b/haptools/sim_genotype.py
@@ -872,10 +872,12 @@ def validate_params(model, mapdir, chroms, popsize, invcf, sample_info, no_repla
             if re.search(r'(?<=chr)(X|\d+)', coord_file) and \
                re.search(r'(?<=chr)(X|\d+)', coord_file).group() in chroms]
     except:
-        raise Exception("Could not parse map directory files.")
+        raise Exception("No valid coordinate files found. Must contain chr{1-22,X} in the file name "
+                        " and end in .map")
     
     if not all_coord_files:
-        raise Exception("No valid coordinate files found. Must contain chr{1-22,X} in the file name.")
+        raise Exception("No valid coordinate files found. Must contain chr{1-22,X} in the file name "
+                        " and end in .map")
     
     # validate popsize
     if not isinstance(popsize, int):

--- a/haptools/sim_genotype.py
+++ b/haptools/sim_genotype.py
@@ -383,7 +383,8 @@ def simulate_gt(model_file, coords_dir, chroms, region, popsize, log, seed=None)
     # remove all chr files not found in chroms list
     all_coord_files = glob.glob(f'{coords_dir}/*.map')
     all_coord_files = [coord_file for coord_file in all_coord_files \
-                if re.search(r'(?<=chr)(X|\d+)', coord_file).group() in chroms]
+                if re.search(r'(?<=chr)(X|\d+)', coord_file) and \
+                   re.search(r'(?<=chr)(X|\d+)', coord_file).group() in chroms]
     all_coord_files.sort(key=numeric_alpha)
 
     if len(all_coord_files) != len(chroms):
@@ -868,7 +869,8 @@ def validate_params(model, mapdir, chroms, popsize, invcf, sample_info, no_repla
     try:
         all_coord_files = glob.glob(f'{mapdir}/*.map')
         all_coord_files = [coord_file for coord_file in all_coord_files \
-            if re.search(r'(?<=chr)(X|\d+)', coord_file).group() in chroms]
+            if re.search(r'(?<=chr)(X|\d+)', coord_file) and \
+               re.search(r'(?<=chr)(X|\d+)', coord_file).group() in chroms]
     except:
         raise Exception("Could not parse map directory files.")
     

--- a/tests/test_outputvcf.py
+++ b/tests/test_outputvcf.py
@@ -718,7 +718,11 @@ def test_model_files():
         validate_params(
             model, faulty_mapdir, chroms, popsize, vcf_file, sampleinfo_file, False
         )
-    assert (str(e.value)) == "Could not parse map directory files."
+    assert (
+        (str(e.value))
+        == "No valid coordinate files found. Must contain chr{1-22,X} in the file name"
+        " and end in .map"
+    )
 
     faulty_mapdir = DATADIR.joinpath("test_map_2")
     with pytest.raises(Exception) as e:
@@ -727,7 +731,8 @@ def test_model_files():
         )
     assert (
         (str(e.value))
-        == "No valid coordinate files found. Must contain chr{1-22,X} in the file name."
+        == "No valid coordinate files found. Must contain chr{1-22,X} in the file name"
+        " and end in .map"
     )
 
     # validate popsize exceptions


### PR DESCRIPTION
Added logic in simgenotype on lines 386-387 and 872-873 to check if file ending in .map will even have chr{1-22,X} before grabbing the group to prevent the code from erroring out even though we have valid coordinate files in the directory.