### PR TITLE
feat: new `Phenotypes.subset()` method

### DIFF
--- a/docs/api/data.rst
+++ b/docs/api/data.rst
@@ -169,7 +169,7 @@ All of the other methods in the :class:`Genotypes` class are inherited, but the 
 
 GenotypesPLINK
 ++++++++++++++
-The :class:`GenotypesPLINK` class offers experimental support for reading and writing PLINK2 PGEN, PVAR, and PSAM files. We are able to read genotypes from a PLINK2 PGEN files in a fraction of the time of VCFs. Reading from VCFs is :math:`O(n*p)`, while reading from PGEN files is approximately :math:`O(1)`.
+The :class:`GenotypesPLINK` class offers experimental support for reading and writing PLINK2 PGEN, PVAR, and PSAM files. We are able to read genotypes from PLINK2 PGEN files in a fraction of the time of VCFs. Reading from VCFs is :math:`O(n*p)`, while reading from PGEN files is approximately :math:`O(1)`.
 
 .. figure:: https://drive.google.com/uc?export=view&id=1_JARKJQ0LX-DzL0XsHW1aiQgLCOJ1ZvC
 

--- a/haptools/data/phenotypes.py
+++ b/haptools/data/phenotypes.py
@@ -348,7 +348,7 @@ class Phenotypes(Data):
         self,
         samples: tuple[str] = None,
         names: tuple[str] = None,
-        inplace: bool = False
+        inplace: bool = False,
     ):
         """
         Subset these phenotypes to a smaller set of samples or a smaller set of names

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -679,6 +679,39 @@ class TestPhenotypes:
         np.testing.assert_allclose(expected1.data, expected2.data[:, :2])
         np.testing.assert_allclose(expected2.data[:, 2], new_phen)
 
+    def test_subset_phenotypes(self):
+        pts = self._get_fake_phenotypes()
+
+        # subset to just the samples we want
+        expected_data = pts.data[:3]
+        expected_names = pts.names
+        samples = ("HG00096", "HG00097", "HG00099")
+        pts_sub = pts.subset(samples=samples)
+        assert pts_sub.samples == samples
+        np.testing.assert_allclose(pts_sub.data, expected_data)
+        assert np.array_equal(pts_sub.names, expected_names)
+
+        # subset to just the names we want
+        expected_data = pts.data[:, [1]]
+        assert len(expected_data.shape) == 2
+        expected_names = (pts.names[1],)
+        names = ("bmi",)
+        pts_sub = pts.subset(names=names)
+        assert pts_sub.samples == pts.samples
+        np.testing.assert_allclose(pts_sub.data, expected_data)
+        assert np.array_equal(pts_sub.names, expected_names)
+
+        # subset both: samples and names
+        expected_data = pts.data[[3, 4], [1,]][:, np.newaxis]
+        assert len(expected_data.shape) == 2
+        expected_names = (pts.names[1],)
+        samples = ("HG00100", "HG00101")
+        names = ("bmi",)
+        pts_sub = pts.subset(samples=samples, names=names)
+        assert pts_sub.samples == samples
+        np.testing.assert_allclose(pts_sub.data, expected_data)
+        assert np.array_equal(pts_sub.names, expected_names)
+
 
 class TestCovariates:
     def _get_expected_covariates(self):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -702,7 +702,8 @@ class TestPhenotypes:
         assert np.array_equal(pts_sub.names, expected_names)
 
         # subset both: samples and names
-        expected_data = pts.data[[3, 4], [1,]][:, np.newaxis]
+        expected_data = pts.data[[3, 4], [1]]
+        espected_data = expected_data[:, np.newaxis]
         assert len(expected_data.shape) == 2
         expected_names = (pts.names[1],)
         samples = ("HG00100", "HG00101")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -703,7 +703,7 @@ class TestPhenotypes:
 
         # subset both: samples and names
         expected_data = pts.data[[3, 4], [1]]
-        espected_data = expected_data[:, np.newaxis]
+        expected_data = expected_data[:, np.newaxis]
         assert len(expected_data.shape) == 2
         expected_names = (pts.names[1],)
         samples = ("HG00100", "HG00101")


### PR DESCRIPTION
...so that we can handle situations (within happler) where samples in a phenotypes file don't appear in the same order as those in the genotypes file

note: this idea first appeared in https://github.com/CAST-genomics/haptools/issues/19#issuecomment-1126651795