### PR TITLE
feat: Added ability to set vcftype for reading str files

### DIFF
--- a/docs/api/data.rst
+++ b/docs/api/data.rst
@@ -178,7 +178,6 @@ All of the other methods in the :class:`Genotypes` class are inherited, but the 
 	genotypes = data.GenotypesTR.load('tests/data/simple_tr.vcf')
 	# make the first sample have 4 and 7 repeats for the alleles of the fourth variant
 	genotypes.data[0, 3] = (4, 7)
-	genotypes.write()
 
 .. _api-data-genotypestr:
 

--- a/haptools/clump.py
+++ b/haptools/clump.py
@@ -7,7 +7,7 @@ import logging
 import math
 import sys
 
-from haptools.data.genotypes import Genotypes, GenotypesVCF, GenotypesTR
+from haptools.data.genotypes import Genotypes, GenotypesPLINK, GenotypesVCF, GenotypesTR
 
 
 class Variant:

--- a/haptools/clump.py
+++ b/haptools/clump.py
@@ -587,6 +587,8 @@ def clumpstr(
         strgts.samples = tuple(np.array(strgts.samples)[str_samples])
 
         # Merge STR and SNP GTs
+        # NOTE if Genotypes is not used and GenotypesVCF is instead it will error because
+        #      GenotypesVCF requires alleles to be present and Genotypes does not
         gts = Genotypes.merge_variants((snpgts, strgts), fname=None)
     elif gts_snps:
         gts = snpgts

--- a/haptools/data/genotypes.py
+++ b/haptools/data/genotypes.py
@@ -829,7 +829,14 @@ class GenotypesTR(Genotypes):
             3. POS
     log: Logger
         See documentation for :py:attr:`~.Genotypes.log`
+    vcftype: str
+        TR vcf type currently being read.
+        {'auto', 'gangstr', 'advntr', 'hipstr', 'eh', 'popstr'}
     """
+
+    def __init__(self, fname: Path | str, log: Logger = None, vcftype: str = "auto"):
+        super().__init__(fname, log)
+        self.vcftype = vcftype
 
     def _variant_arr(self, record: Variant):
         """
@@ -851,6 +858,7 @@ class GenotypesTR(Genotypes):
         region: str = None,
         samples: list[str] = None,
         variants: set[str] = None,
+        vcftype: str = "auto",
     ) -> Genotypes:
         """
         Load STR genotypes from a VCF file
@@ -873,7 +881,7 @@ class GenotypesTR(Genotypes):
         Genotypes
             A Genotypes object with the data loaded into its properties
         """
-        genotypes = cls(fname)
+        genotypes = cls(fname, vcftype=vcftype)
         genotypes.read(region, samples, variants)
         genotypes.check_phase()
         return genotypes
@@ -895,7 +903,9 @@ class GenotypesTR(Genotypes):
             TRRecord objects yielded from TRRecordHarmonizer.
         """
         vcfiter = vcf(region)
-        tr_records = trh.TRRecordHarmonizer(vcffile=vcf, vcfiter=vcfiter, region=region)
+        tr_records = trh.TRRecordHarmonizer(
+            vcffile=vcf, vcfiter=vcfiter, region=region, vcftype=self.vcftype
+        )
         return tr_records
 
     def _return_data(self, variant: trh.TRRecord):


### PR DESCRIPTION
When loading a GenotypeTR class you can now specify what the type of vcf you are currently reading.

Example
```
genotypes = data.GenotypesTR.load('tests/data/simple_tr.vcf', vcftype='hipstr')
```
you can choose between
```
vcftype : {'auto', 'gangstr', 'advntr', 'hipstr', 'eh', 'popstr'}
```