### PR TITLE
fix: explicitly ignore repeats in the `ld` command

### DIFF
--- a/docs/commands/ld.rst
+++ b/docs/commands/ld.rst
@@ -8,7 +8,10 @@ Compute the pair-wise LD (`Pearson's correlation coefficient <https://numpy.org/
 
 The ``ld`` command takes as input a set of genotypes in VCF and a list of haplotypes (specified as a :doc:`.hap file </formats/haplotypes>`) and outputs a new :doc:`.hap file </formats/haplotypes>` with the computed LD values in an extra field.
 
-By default, LD is computed with each haplotype in the **.hap** file. To compute LD with the variants in the genotypes file instead, you should use the `--from-gts <#cmdoption-haptools-ld-from-gts>`_ switch. When this mode is enabled, the **.hap** output will be replaced by an :doc:`.ld file </formats/ld>`.
+By default, LD is computed with each haplotype in the ``.hap`` file. To compute LD with the variants in the genotypes file instead, you should use the `--from-gts <#cmdoption-haptools-ld-from-gts>`_ switch. When this mode is enabled, the ``.hap`` output will be replaced by an :doc:`.ld file </formats/ld>`.
+
+.. note::
+	Repeats are not currently supported by the ``ld`` command. Any repeats in your ``.hap`` file will be ignored.
 
 You may also specify genotypes in PLINK2 PGEN format instead of VCF format. See the documentation for genotypes in :ref:`the format docs <formats-genotypesplink>` for more information.
 

--- a/tests/test_ld.py
+++ b/tests/test_ld.py
@@ -32,6 +32,29 @@ V\tchr21.q.3365*11\t26938989\t26938989\t21_26938989_G_A\tA
     assert result.exit_code == 0
 
 
+def test_simple_with_repeat(capfd):
+    gt_file = DATADIR / "simple.vcf"
+    hp_file = DATADIR / "simple.hap"
+
+    cmd = f"ld H1 {gt_file} {hp_file}"
+    runner = CliRunner()
+    result = runner.invoke(main, cmd.split(" "), catch_exceptions=False)
+    captured = capfd.readouterr()
+    assert captured.out
+    expected = captured.out
+    assert result.exit_code == 0
+
+    # now try again. The result should be the same because it ignores repeats
+    hp_file = DATADIR / "simple_tr.hap"
+
+    cmd = f"ld H1 {gt_file} {hp_file}"
+    runner = CliRunner()
+    result = runner.invoke(main, cmd.split(" "), catch_exceptions=False)
+    captured = capfd.readouterr()
+    assert expected == captured.out
+    assert result.exit_code == 0
+
+
 def test_basic_variant(capfd):
     expected = """#\torderH\tld
 #\tversion\t0.2.0


### PR DESCRIPTION
A future release of haptools will add support for repeats in the `ld` command. Unfortunately, that will very likely require us to make breaking changes to the `ld` command to make the interface flexible enough for users to be able to specify all of the possible ways to compute LD with a repeat or a set of repeats. So for now, we will just delay the breaking changes and explicitly ignore repeats in the meantime.

Users who are interested in computing LD with repeats may use the haptools API or PLINK2's `--ld dosage` feature until we add support.