### PR TITLE
fix: `UnboundLocalError` arising from headerless `.hap` files

### DIFF
--- a/haptools/__init__.py
+++ b/haptools/__init__.py
@@ -4,7 +4,7 @@ except ImportError:
     # handles py3.7, since importlib.metadata was introduced in py3.8
     from importlib_metadata import version, PackageNotFoundError
 
-    try:
-        __version__ = version(__name__)
-    except PackageNotFoundError:
-        __version__ = "unknown"
+try:
+    __version__ = version(__name__)
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/haptools/data/haplotypes.py
+++ b/haptools/data/haplotypes.py
@@ -1231,7 +1231,7 @@ class Haplotypes(Data):
                             # These are usually just comment lines, so we can ignore it
                             pass
                     else:
-                        if header_lines:
+                        if header_lines is not None:
                             metas, extras = self.check_header(header_lines)
                             types = self._get_field_types(extras, metas.get("order"))
                             header_lines = None

--- a/haptools/data/haplotypes.py
+++ b/haptools/data/haplotypes.py
@@ -101,7 +101,7 @@ class Extra:
 
 class classproperty(object):
     """
-    A daad-simple read-only decorator that combines the functionality of
+    A dead-simple read-only decorator that combines the functionality of
     @classmethod and @property
 
     Stolen from https://stackoverflow.com/a/13624858/16815703

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1184,6 +1184,20 @@ class TestHaplotypes:
         haps = Haplotypes.load(DATADIR / "basic.hap.gz")
         assert expected == haps.data
 
+    def test_load_no_header(self):
+        expected = self._basic_haps()
+
+        # what if we remove the header line, can we still load it?
+        # let's try to make a version without the header
+        no_header_file = DATADIR / "basic_no_header.hap"
+        with open(DATADIR / "basic.hap", "r") as fr, open(no_header_file, "w") as fw:
+            fw.writelines([ln for ln in fr.readlines() if not ln.startswith("#\t")])
+
+        haps = Haplotypes.load(no_header_file)
+        assert expected == haps.data
+
+        no_header_file.unlink()
+
     def test_iterate(self):
         exp_full = self._basic_haps()
 


### PR DESCRIPTION
Thanks to @XimeiWulilyy for reporting the issue and providing a detailed report and minimally reproducible example!