### PR TITLE
feat: convert `samples` arg in `Genotypes` classes into a set

### DIFF
--- a/haptools/__main__.py
+++ b/haptools/__main__.py
@@ -491,10 +491,10 @@ def simphenotype(
         )
     if samples_file:
         with samples_file as samps_file:
-            samples = samps_file.read().splitlines()
+            samples = set(samps_file.read().splitlines())
     elif samples:
-        # needs to be converted from tuple to list
-        samples = list(samples)
+        # needs to be converted from tuple to set
+        samples = set(samples)
     else:
         samples = None
 
@@ -657,10 +657,10 @@ def transform(
         )
     if samples_file:
         with samples_file as samps_file:
-            samples = samps_file.read().splitlines()
+            samples = set(samps_file.read().splitlines())
     elif samples:
-        # needs to be converted from tuple to list
-        samples = list(samples)
+        # needs to be converted from tuple to set
+        samples = set(samples)
     else:
         samples = None
 
@@ -828,10 +828,10 @@ def ld(
         )
     if samples_file:
         with samples_file as samps_file:
-            samples = samps_file.read().splitlines()
+            samples = set(samps_file.read().splitlines())
     elif samples:
-        # needs to be converted from tuple to list
-        samples = list(samples)
+        # needs to be converted from tuple to set
+        samples = set(samples)
     else:
         samples = None
 

--- a/haptools/data/genotypes.py
+++ b/haptools/data/genotypes.py
@@ -134,7 +134,7 @@ class Genotypes(Data):
             Defaults to loading all genotypes
         samples : set[str], optional
             A subset of the samples from which to extract genotypes
-            
+
             Note that they are loaded in the same order as in the file
 
             Defaults to loading genotypes from all samples

--- a/haptools/data/genotypes.py
+++ b/haptools/data/genotypes.py
@@ -334,8 +334,7 @@ class Genotypes(Data):
                     "Samples cannot be loaded in a particular order. "
                     "Use subset() to reorder the samples after loading them."
                 )
-            else:
-                samples = list(samples)
+            samples = list(samples)
         vcf = VCF(str(self.fname), samples=samples, lazy=True)
         self.samples = tuple(vcf.samples)
         # call another function to force the lines above to be run immediately

--- a/haptools/ld.py
+++ b/haptools/ld.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import logging
 from pathlib import Path
 from dataclasses import dataclass, field
 
@@ -50,7 +51,7 @@ def calc_ld(
     genotypes: Path,
     haplotypes: Path,
     region: str = None,
-    samples: list[str] = None,
+    samples: set[str] = None,
     ids: tuple[str] = None,
     chunk_size: int = None,
     discard_missing: bool = False,
@@ -72,7 +73,7 @@ def calc_ld(
     region : str, optional
         See documentation for :py:meth:`~.data.Genotypes.read`
         and :py:meth:`~.data.Haplotypes.read`
-    samples : list[str], optional
+    samples : set[str], optional
         See documentation for :py:meth:`~.data.Genotypes.read`
     ids: set[str], optional
         A subset of haplotype IDs to obtain from the .hap file. All others

--- a/haptools/sim_phenotype.py
+++ b/haptools/sim_phenotype.py
@@ -303,7 +303,7 @@ def simulate_pt(
     prevalence: float = None,
     normalize: bool = True,
     region: str = None,
-    samples: list[str] = None,
+    samples: set[str] = None,
     haplotype_ids: set[str] = None,
     chunk_size: int = None,
     repeats: Path = None,
@@ -352,13 +352,10 @@ def simulate_pt(
         match!
 
         Defaults to loading all haplotypes
-    sample : tuple[str], optional
+    samples : set[str], optional
         A subset of the samples from which to extract genotypes
 
         Defaults to loading genotypes from all samples
-    samples_file : Path, optional
-        A single column txt file containing a list of the samples (one per line) to
-        subset from the genotypes file
     haplotype_ids: set[str], optional
         A list of haplotype IDs to obtain from the .hap file. All others are ignored.
 

--- a/haptools/transform.py
+++ b/haptools/transform.py
@@ -5,8 +5,8 @@ from collections import namedtuple
 from dataclasses import dataclass, field
 
 import numpy as np
+from cyvcf2 import VCF
 import numpy.typing as npt
-from cyvcf2 import VCF, Variant
 from pysam import VariantFile
 
 from . import data
@@ -28,7 +28,7 @@ class HaplotypeAncestry(data.Haplotype):
         default=(data.Extra("ancestry", "s", "Local ancestry"),),
     )
 
-    def transform(self, genotypes: data.GenotypesVCF) -> npt.NDArray[bool]:
+    def transform(self, genotypes: data.GenotypesVCF) -> npt.NDArray:
         """
         Transform a genotypes matrix via the current haplotype and its ancestral
         population
@@ -80,7 +80,7 @@ class HaplotypesAncestry(data.Haplotypes):
         fname: Path | str,
         haplotype: type[HaplotypeAncestry] = HaplotypeAncestry,
         variant: type[data.Variant] = data.Variant,
-        log: Logger = None,
+        log: logging.Logger = None,
     ):
         """
         Contrasting with the base Haplotypes class: this class uses HaplotypeAncestry
@@ -171,11 +171,11 @@ class GenotypesAncestry(data.GenotypesVCF):
     ancestry : np.array
         The ancestral population of each allele in each sample of
         :py:attr:`~.GenotypesAncestry.data`
-    log: Logger
+    log: logging.Logger
         See documentation for :py:attr:`~.Genotypes.log`
     """
 
-    def __init__(self, fname: Path | str, log: Logger = None):
+    def __init__(self, fname: Path | str, log: logging.Logger = None):
         super().__init__(fname, log)
         self.ancestry = None
         self.valid_labels = None
@@ -227,7 +227,7 @@ class GenotypesAncestry(data.GenotypesVCF):
     def read(
         self,
         region: str = None,
-        samples: list[str] = None,
+        samples: set[str] = None,
         variants: set[str] = None,
         max_variants: int = None,
     ):

--- a/haptools/transform.py
+++ b/haptools/transform.py
@@ -532,7 +532,7 @@ def transform_haps(
     genotypes: Path,
     haplotypes: Path,
     region: str = None,
-    samples: list[str] = None,
+    samples: set[str] = None,
     haplotype_ids: set[str] = None,
     chunk_size: int = None,
     discard_missing: bool = False,
@@ -552,7 +552,7 @@ def transform_haps(
     region : str, optional
         See documentation for :py:meth:`~.data.Genotypes.read`
         and :py:meth:`~.data.Haplotypes.read`
-    samples : list[str], optional
+    samples : set[str], optional
         See documentation for :py:meth:`~.data.Genotypes.read`
     haplotype_ids: set[str], optional
         A set of haplotype IDs to obtain from the .hap file. All others are ignored.

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -499,8 +499,9 @@ class TestGenotypesPLINK:
         expected_data = expected_data[[1, 3]]
 
         gts = GenotypesPLINK(DATADIR / "simple.pgen")
-        samples = set([expected.samples[1], expected.samples[3]])
-        gts.read(region="1:10115-10117", samples=samples)
+        samples = [expected.samples[1], expected.samples[3]]
+        samples_set = set(samples)
+        gts.read(region="1:10115-10117", samples=samples_set)
         gts.check_phase()
         np.testing.assert_allclose(gts.data, expected_data)
         assert gts.samples == tuple(samples)
@@ -510,7 +511,7 @@ class TestGenotypesPLINK:
 
         gts = GenotypesPLINK(DATADIR / "simple.pgen")
         variants = {"1:10117:C:A"}
-        gts.read(region="1:10115-10117", samples=samples, variants=variants)
+        gts.read(region="1:10115-10117", samples=samples_set, variants=variants)
         gts.check_phase()
         np.testing.assert_allclose(gts.data, expected_data)
         assert gts.samples == tuple(samples)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -309,16 +309,6 @@ class TestGenotypes:
         assert gts.data.shape[2] == gts2.data.shape[2]
         assert gts.data.shape[1] == (gts1.data.shape[1] + gts2.data.shape[1])
 
-    def test_reorder_samples(self):
-        # can we load the data from the VCF?
-        gts = Genotypes(DATADIR / "simple.vcf.gz", reorder_samples=True)
-        gts.read(region="1:10115-10117", samples=["HG00097", "HG00096", "HG00099"])
-        assert gts.samples == ("HG00097", "HG00096", "HG00099")
-
-        gts = Genotypes(DATADIR / "simple.vcf.gz", reorder_samples=False)
-        gts.read(region="1:10115-10117", samples=["HG00097", "HG00096", "HG00099"])
-        assert gts.samples == ("HG00096", "HG00097", "HG00099")
-
 
 class TestGenotypesPLINK:
     def _get_fake_genotypes_plink(self):
@@ -699,16 +689,6 @@ class TestGenotypesPLINK:
         fname.with_suffix(".pvar").unlink()
         fname.unlink()
 
-    def test_reorder_samples(self):
-        # can we load the data from the VCF?
-        gts = GenotypesPLINK(DATADIR / "simple.pgen", reorder_samples=True)
-        gts.read(region="1:10115-10117", samples=["HG00097", "HG00096", "HG00099"])
-        assert gts.samples == ("HG00097", "HG00096", "HG00099")
-
-        gts = GenotypesPLINK(DATADIR / "simple.pgen", reorder_samples=False)
-        gts.read(region="1:10115-10117", samples=["HG00097", "HG00096", "HG00099"])
-        assert gts.samples == ("HG00096", "HG00097", "HG00099")
-
 
 class TestGenotypesPLINKTR:
     def _get_fake_genotypes_multiallelic(self):
@@ -768,16 +748,6 @@ class TestGenotypesPLINKTR:
         gts.read()
         # check genotypes
         np.testing.assert_allclose(expected_alleles, gts.data)
-
-    def test_reorder_samples(self):
-        # can we load the data from the VCF?
-        gts = GenotypesPLINKTR(DATADIR / "simple-tr.pgen", reorder_samples=True)
-        gts.read(samples=["HG00097", "HG00096", "HG00099"])
-        assert gts.samples == ("HG00097", "HG00096", "HG00099")
-
-        gts = GenotypesPLINKTR(DATADIR / "simple-tr.pgen", reorder_samples=False)
-        gts.read(samples=["HG00097", "HG00096", "HG00099"])
-        assert gts.samples == ("HG00096", "HG00097", "HG00099")
 
 
 class TestPhenotypes:
@@ -1877,16 +1847,6 @@ class TestGenotypesVCF:
         assert gts.data.shape[2] == gts1.data.shape[2]
         assert gts.data.shape[1] == (gts1.data.shape[1] + gts2.data.shape[1])
 
-    def test_reorder_samples(self):
-        gts = GenotypesVCF(DATADIR / "simple.vcf.gz", reorder_samples=True)
-        gts.read(region="1:10113-10115", samples=["HG00097", "HG00096", "HG00099"])
-        assert gts.samples == ("HG00097", "HG00096", "HG00099")
-
-        gts = GenotypesVCF(DATADIR / "simple.vcf.gz", reorder_samples=False)
-        gts.read(region="1:10113-10115", samples=["HG00097", "HG00096", "HG00099"])
-        assert gts.samples == ("HG00096", "HG00097", "HG00099")
-
-
 class TestGenotypesTR:
     def _get_fake_tr_alleles(self):
         return np.array(
@@ -1917,16 +1877,6 @@ class TestGenotypesTR:
         # Check that everything matches what we expected
         for idx, line in enumerate(gts):
             np.testing.assert_allclose(line.data[:, :3], expected[:, idx])
-
-    def test_reorder_samples(self):
-        gts = GenotypesTR(DATADIR / "simple_tr.vcf", reorder_samples=True)
-        gts.read(samples=["HG00097", "HG00096", "HG00099"])
-        assert gts.samples == ("HG00097", "HG00096", "HG00099")
-
-        gts = GenotypesTR(DATADIR / "simple_tr.vcf", reorder_samples=False)
-        gts.read(samples=["HG00097", "HG00096", "HG00099"])
-        assert gts.samples == ("HG00096", "HG00097", "HG00099")
-
 
 class TestBreakpoints:
     def _get_expected_breakpoints(self):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -194,7 +194,8 @@ class TestGenotypes:
 
         gts = Genotypes(DATADIR / "simple.vcf.gz")
         samples = ["HG00097", "HG00100"]
-        gts.read(region="1:10115-10117", samples=samples)
+        samples_set = set(samples)
+        gts.read(region="1:10115-10117", samples=samples_set)
         np.testing.assert_allclose(gts.data, expected)
         assert gts.samples == tuple(samples)
 
@@ -202,9 +203,8 @@ class TestGenotypes:
         expected = expected[:, [1]]
 
         gts = Genotypes(DATADIR / "simple.vcf.gz")
-        samples = ["HG00097", "HG00100"]
         variants = {"1:10117:C:A"}
-        gts.read(region="1:10115-10117", samples=samples, variants=variants)
+        gts.read(region="1:10115-10117", samples=samples_set, variants=variants)
         np.testing.assert_allclose(gts.data, expected)
         assert gts.samples == tuple(samples)
 
@@ -499,7 +499,7 @@ class TestGenotypesPLINK:
         expected_data = expected_data[[1, 3]]
 
         gts = GenotypesPLINK(DATADIR / "simple.pgen")
-        samples = [expected.samples[1], expected.samples[3]]
+        samples = set([expected.samples[1], expected.samples[3]])
         gts.read(region="1:10115-10117", samples=samples)
         gts.check_phase()
         np.testing.assert_allclose(gts.data, expected_data)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1847,6 +1847,7 @@ class TestGenotypesVCF:
         assert gts.data.shape[2] == gts1.data.shape[2]
         assert gts.data.shape[1] == (gts1.data.shape[1] + gts2.data.shape[1])
 
+
 class TestGenotypesTR:
     def _get_fake_tr_alleles(self):
         return np.array(
@@ -1877,6 +1878,7 @@ class TestGenotypesTR:
         # Check that everything matches what we expected
         for idx, line in enumerate(gts):
             np.testing.assert_allclose(line.data[:, :3], expected[:, idx])
+
 
 class TestBreakpoints:
     def _get_expected_breakpoints(self):


### PR DESCRIPTION
closes #228 and overrides it

## background
The `Genotypes.read` and `Genotypes.__init__` methods expect samples to be provided as a list but make no guarantee that the samples will be loaded in the ordering requested. (This is because the underlying libraries that we use do not make this guarantee either.)

We first attempted to solve this issue in #225 by automatically reordering after reading the genotypes. But then we realized this would double the memory of the `read()` method.

PR #228 takes a different approach to the problem by adding a `reorder_samples` argument to the `Genotypes` classes that would do the reordering only if it is requested. This approach would also have required us to do more work to implement extra checks (see https://github.com/CAST-genomics/haptools/pull/228#issuecomment-1816860996). It also got us asking, from a design perspective, what makes the `samples` argument any different than the `variants` argument, which is currently typed as a set?

## proposal
We ultimately decided that a better design approach would be to just copy the type of the `variants` argument and make the `samples` argument into a set, as well. If a user passes anything that isn't a set, we warn them and request that they use the `subset()` method after loading the genotypes. This approach ended up being a bit cleaner since the GenotypesPLINK classes actually need it to be a set, anyway.