### PR TITLE
fix: disable numpy 2.0 since our dependencies don't yet work with it

### DIFF
--- a/dev-env.yml
+++ b/dev-env.yml
@@ -4,10 +4,10 @@ channels:
   - nodefaults
 dependencies:
   - conda-forge::python=3.8 # the lowest version of python that we formally support
-  - conda-forge::pip==23.3.2
-  - conda-forge::poetry==1.7.1
-  - conda-forge::nox==2023.04.22
-  - conda-forge::poetry-plugin-export==1.6.0
+  - conda-forge::pip==24.0
+  - conda-forge::poetry==1.8.3
+  - conda-forge::nox==2024.4.15
+  - conda-forge::poetry-plugin-export==1.8.0
   - pip:
     - nox-poetry==1.0.3
     - poetry-conda==0.1.1

--- a/poetry.lock
+++ b/poetry.lock
@@ -1663,4 +1663,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<4.0"
-content-hash = "3e24aa6f829f7d2500dea2dd9c6009a7a2c2009b36370d26f2d390bdb7745c98"
+content-hash = "adcba4ad16e8b66dabf4cd9df4144b54db5dd177d852ecfd04265e84a21883ff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
-numpy = ">=1.20.0"
+numpy = ">=1.20.0,<2.0"
 click = ">=8.0.3"
 pysam = ">=0.19.0"
 cyvcf2 = ">=0.30.14"


### PR DESCRIPTION
numpy 2.0 is coming out in 11 days! I hope the python world is ready