### PR TITLE
ci: use trusted publishing with pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    # Specifying a GitHub environment is optional, but strongly encouraged
     environment: release
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
@@ -58,10 +57,10 @@ jobs:
 
       - name: Publish package on TestPyPI
         if: ${{ steps.release.outputs.release_created }}
-        uses: pypa/gh-action-pypi-publish@v1.5.0
+        uses: pypa/gh-action-pypi-publish@v1.8.14
         with:
           repository_url: https://test.pypi.org/legacy/
 
       - name: Publish package on PyPI
         if: ${{ steps.release.outputs.release_created }}
-        uses: pypa/gh-action-pypi-publish@v1.5.0
+        uses: pypa/gh-action-pypi-publish@v1.8.14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v3
         id: release
@@ -55,13 +60,8 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         uses: pypa/gh-action-pypi-publish@v1.5.0
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
 
       - name: Publish package on PyPI
         if: ${{ steps.release.outputs.release_created }}
         uses: pypa/gh-action-pypi-publish@v1.5.0
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
see https://docs.pypi.org/trusted-publishers for more details

This is a more secure way of publishing to PyPI. I've configured [the new GitHub "environment" system](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) to require reviews from someone in @CAST-genomics/haptools each time before a new release gets uploaded to PyPI