### PR TITLE
fix: issue warnings instead of errors when trying to check the header of hap files and issue error when output of transform is not provided to simphenotype

### DIFF
--- a/haptools/data/haplotypes.py
+++ b/haptools/data/haplotypes.py
@@ -933,8 +933,10 @@ class Haplotypes(Data):
         # if there are any fields left...
         if any(exp_extras.values()):
             names = tuple(
-                f"#{t} {tval}" for t in exp_extras
-                for tval in exp_extras[t] if exp_extras[t]
+                f"#{t} {tval}"
+                for t in exp_extras
+                for tval in exp_extras[t]
+                if exp_extras[t]
             )
             err_msgr(
                 "Expected the input .hap file to have these extra fields, but they "

--- a/haptools/data/haplotypes.py
+++ b/haptools/data/haplotypes.py
@@ -861,7 +861,7 @@ class Haplotypes(Data):
             Whether to also check the version of the file
         softly: bool, optional
             If True, then this function will not raise any ValueErrors. Instead, it
-            will only issue errors via the logging module, which may be ignored.
+            will only issue warnings via the logging module, which may be ignored.
 
         Raises
         ------
@@ -881,7 +881,7 @@ class Haplotypes(Data):
         if softly:
 
             def err_msgr(msg):
-                self.log.error(msg)
+                self.log.warning(msg)
 
         else:
 
@@ -932,7 +932,10 @@ class Haplotypes(Data):
                     )
         # if there are any fields left...
         if any(exp_extras.values()):
-            names = [n for name in exp_extras.values() for n in name]
+            names = tuple(
+                f"#{t} {tval}" for t in exp_extras
+                for tval in exp_extras[t] if exp_extras[t]
+            )
             err_msgr(
                 "Expected the input .hap file to have these extra fields, but they "
                 f"don't seem to be declared in the header: {*names,}"

--- a/haptools/sim_phenotype.py
+++ b/haptools/sim_phenotype.py
@@ -444,10 +444,10 @@ def simulate_pt(
         gt = Genotypes.merge_variants((gt, tr_gt), fname=None)
 
     # check that all of the genotypes were loaded successfully and warn otherwise
-    if len(haplotype_ids) < len(gt.variants):
+    if len(haplotype_ids) > len(gt.variants):
         diff = list(haplotype_ids.difference(gt.variants["id"]))
         first_few = 5 if len(diff) > 5 else len(diff)
-        log.warning(
+        log.error(
             f"{len(diff)} effects could not be found in the genotypes file. Check "
             "that the IDs in your .snplist or .hap file correspond with those in the "
             "genotypes file. Here are the first few missing variants: "


### PR DESCRIPTION
We were issuing errors in the .hap reader before but it turns out that there are perfectly legitimate reasons for the header to lack an extra field. For example, if a hap file only contains haplotypes (and not repeats) and we try to provide the hap file to `simphenotype`, which expects both haplotypes and repeats to be declared in the header.

This PR also switches on a message in `simphenotype` that would warn when the output of `transform` is not properly passed to `simphenotype`. Incidentally, I do this all the time 😅  It also converts the warning to an error.