### PR TITLE
feat: support for Apple M1 silicon

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
           - { python: "3.12", os: "ubuntu-latest", session: "tests" }
           # - { python: "3.11", os: "windows-latest", session: "tests" }
           - { python: "3.9", os: "macos-13", session: "tests" }
-          - { python: "3.9", os: "macos-14", session: "tests" }
+          - { python: "3.11", os: "macos-14", session: "tests" }
           - { python: "3.8", os: "ubuntu-latest", session: "size" }
 
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
           - { python: "3.12", os: "ubuntu-latest", session: "tests" }
           # - { python: "3.11", os: "windows-latest", session: "tests" }
           - { python: "3.9", os: "macos-13", session: "tests" }
-          - { python: "3.11", os: "macos-14", session: "tests" }
+          - { python: "3.11", os: "macos-latest", session: "tests" }
           - { python: "3.8", os: "ubuntu-latest", session: "size" }
 
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
           - { python: "3.12", os: "ubuntu-latest", session: "tests" }
           # - { python: "3.11", os: "windows-latest", session: "tests" }
           - { python: "3.9", os: "macos-13", session: "tests" }
-         - { python: "3.9", os: "macos-14", session: "tests" }
+          - { python: "3.9", os: "macos-14", session: "tests" }
           - { python: "3.8", os: "ubuntu-latest", session: "size" }
 
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
           - { python: "3.12", os: "ubuntu-latest", session: "tests" }
           # - { python: "3.11", os: "windows-latest", session: "tests" }
           - { python: "3.9", os: "macos-13", session: "tests" }
+         - { python: "3.9", os: "macos-14", session: "tests" }
           - { python: "3.8", os: "ubuntu-latest", session: "size" }
 
     env:


### PR DESCRIPTION
Does haptools run on M1 Apple silicon now that our dependencies have added support for it? (See https://github.com/bioconda/bioconda-recipes/pull/50219 and https://github.com/bioconda/bioconda-recipes/pull/50220)

Let's add a test to our CI for this. If it works, then we can add `osx-arm64` to the "additional platforms" that are supported in our bioconda recipe