### PR TITLE
fix: load an empty array if there are no variants in `GenotypesVCF.read`

### DIFF
--- a/haptools/data/genotypes.py
+++ b/haptools/data/genotypes.py
@@ -203,9 +203,11 @@ class Genotypes(Data):
                 "Failed to load genotypes. If you specified a region, check that the"
                 " contig name matches! For example, double-check the 'chr' prefix."
             )
-        # transpose the GT matrix so that samples are rows and variants are columns
-        self.log.info(f"Transposing genotype matrix of size {self.data.shape}")
-        self.data = self.data.transpose((1, 0, 2))
+            self.data = np.empty(shape=(0, 0, 0), dtype=self.data.dtype)
+        else:
+            # transpose the GT matrix so that samples are rows and variants are columns
+            self.log.info(f"Transposing genotype matrix of size {self.data.shape}")
+            self.data = self.data.transpose((1, 0, 2))
 
     def _variant_arr(self, record: Variant):
         """

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -189,6 +189,13 @@ class TestGenotypes:
         np.testing.assert_allclose(gts.data, expected)
         assert gts.samples == ("HG00096", "HG00097", "HG00099", "HG00100", "HG00101")
 
+        # what happens if we ask for a region with no variants?
+        gts = Genotypes(DATADIR / "simple.vcf.gz")
+        gts.read(region="1:10125-10140")
+        expected_empty = np.empty((0, 0, 0), dtype=np.uint8)
+        np.testing.assert_allclose(gts.data, expected_empty)
+        assert gts.samples == ("HG00096", "HG00097", "HG00099", "HG00100", "HG00101")
+
         # subset for just the samples we want
         expected = expected[[1, 3]]
 

--- a/tests/test_simphenotype.py
+++ b/tests/test_simphenotype.py
@@ -677,9 +677,10 @@ class TestSimPhenotypeCLI:
         gt_file = DATADIR / "simple_tr.vcf"
         hp_file = DATADIR / "simple_tr.hap"
 
+        # simulate from a mix of one haplotype and one repeat
         cmd = (
             f"simphenotype --repeats {gt_file} --id 1:10114:GTT "
-            f"{tmp_transform} {hp_file}"
+            f"--id H1 {tmp_transform} {hp_file}"
         )
         runner = CliRunner()
         result = runner.invoke(main, cmd.split(" "), catch_exceptions=False)


### PR DESCRIPTION
Previous behavior was to error out with a cryptic ValueError and raise a warning. Now, we still raise the warning but we don't error out.