### PR TITLE
ci: handle deprecations in gh actions and devcontainer

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -7,7 +7,7 @@
 	"features": {
 		"ghcr.io/rocker-org/devcontainer-features/miniforge:1": {
 			"version": "latest",
-			"variant": "Mambaforge"
+			"variant": "Miniforge"
 		}
 	},
 

--- a/.github/workflows/conventional-prs.yml
+++ b/.github/workflows/conventional-prs.yml
@@ -18,6 +18,6 @@ jobs:
       statuses: write  # for amannn/action-semantic-pull-request to mark status of analyzed PR
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.0.2
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,12 +80,12 @@ jobs:
         run: |
           nox --verbose --python=${{ matrix.python }}
 
-      - name: Upload coverage data
-        if: always() && matrix.session == 'tests'
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-data
-          path: ".coverage.*"
+      # - name: Upload coverage data
+      #   if: always() && matrix.session == 'tests'
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: coverage-data
+      #     path: ".coverage.*"
 
   large-files:
     name: File sizes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,11 +31,10 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
 
-      - name: Setup Mambaforge
+      - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: haptools
-          miniforge-variant: Mambaforge
           auto-activate-base: false
           miniforge-version: latest
           use-mamba: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,7 +95,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check for large files
-        uses: ppremk/lfs-warning@v3
+        uses: ppremk/lfs-warning@v3.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }} # Optional
           filesizelimit: 500000b

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         shell: bash
 
       - name: Cache Conda env
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.CONDA }}/envs
           key:
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'
-        uses: "actions/upload-artifact@v3"
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-data
           path: ".coverage.*"
@@ -95,7 +95,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check for large files
-        uses: actionsdesk/lfs-warning@v3.2
+        uses: ppremk/lfs-warning@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }} # Optional
           filesizelimit: 500000b


### PR DESCRIPTION
Mambaforge is being deprecated https://github.com/conda-incubator/setup-miniconda/pull/360. Also old versions of nodejs in GitHub actions.

This PR cleans up all of the warnings in our CI. For an example, compare [before](https://github.com/CAST-genomics/haptools/actions/runs/11167234622) vs [after](https://github.com/CAST-genomics/haptools/actions/runs/11167563294).