### PR TITLE
build: drop support for py 3.8 and lock at py 3.9 for development

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -15,7 +15,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "mamba env create -n haptools -f dev-env.yml && conda run -n haptools poetry config virtualenvs.in-project true && conda run -n haptools poetry install",
+	"postCreateCommand": "mamba env create -y -n haptools -f dev-env.yml && conda run -n haptools poetry config virtualenvs.in-project true && conda run -n haptools poetry install",
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -4,12 +4,11 @@
 	"name": "Ubuntu",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"ghcr.io/rocker-org/devcontainer-features/miniforge:2": {}
 	},
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
@@ -23,7 +22,8 @@
 			"extensions": [
 				"ms-python.python",
 				"ms-vscode.live-server",
-				"ms-python.black-formatter"
+				"ms-python.black-formatter",
+				"GitHub.vscode-github-actions"
 			],
 			"settings": {
 				"python.analysis.typeCheckingMode": "off", // TODO: set to "strict"
@@ -38,9 +38,17 @@
 				"python.testing.pytestEnabled": true,
 				"python.testing.unittestEnabled": false,
 				"terminal.integrated.environmentChangesRelaunch": true,
-				"editor.defaultFormatter": "ms-python.black-formatter",
+				"[python]": {
+					"editor.defaultFormatter": "ms-python.black-formatter",
+					"editor.formatOnSave": true
+				},
+				"black-formatter.importStrategy": "fromEnvironment",
+				"black-formatter.showNotification": "always",
 				"terminal.integrated.hideOnStartup": "always",
-				"files.eol": "\n"
+				"files.eol": "\n",
+				"git.autofetch": true,
+				"git.enableSmartCommit": true,
+				"git.confirmSync": false
 			}
 		}
 	}

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -22,6 +22,7 @@
 		"vscode": {
 			"extensions": [
 				"ms-python.python",
+				"ms-vscode.live-server",
 				"ms-python.black-formatter"
 			],
 			"settings": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8' # keep synced with dev-env.yml
+          python-version: '3.9' # keep synced with dev-env.yml
 
       - name: Upgrade pip
         if: ${{ steps.release.outputs.release_created }}
@@ -37,7 +37,7 @@ jobs:
       - name: Install Poetry
         if: ${{ steps.release.outputs.release_created }}
         run: |
-          pip install 'poetry==1.8.3'  # keep version synced with dev-env.yml
+          pip install 'poetry==1.8.5'  # keep version synced with dev-env.yml
           poetry --version
 
       - name: Bump version for developmental release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
           - { python: "3.13", os: "ubuntu-latest", session: "tests" }
           # - { python: "3.11", os: "windows-latest", session: "tests" }
           - { python: "3.9", os: "macos-13", session: "tests" }
-          - { python: "3.13", os: "macos-latest", session: "tests" }
+          - { python: "3.12", os: "macos-latest", session: "tests" }
           - { python: "3.9", os: "ubuntu-latest", session: "size" }
 
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { python: "3.8", os: "ubuntu-latest", session: "lint" }
+          - { python: "3.9", os: "ubuntu-latest", session: "lint" }
           - { python: "3.7", os: "ubuntu-latest", session: "tests" }
           - { python: "3.8", os: "ubuntu-latest", session: "tests" }
           - { python: "3.9", os: "ubuntu-latest", session: "tests" }
@@ -21,7 +21,7 @@ jobs:
           # - { python: "3.11", os: "windows-latest", session: "tests" }
           - { python: "3.9", os: "macos-13", session: "tests" }
           - { python: "3.11", os: "macos-latest", session: "tests" }
-          - { python: "3.8", os: "ubuntu-latest", session: "size" }
+          - { python: "3.9", os: "ubuntu-latest", session: "size" }
 
     env:
       NOXSESSION: ${{ matrix.session }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
           - { python: "3.13", os: "ubuntu-latest", session: "tests" }
           # - { python: "3.11", os: "windows-latest", session: "tests" }
           - { python: "3.9", os: "macos-13", session: "tests" }
-          - { python: "3.11", os: "macos-latest", session: "tests" }
+          - { python: "3.13", os: "macos-latest", session: "tests" }
           - { python: "3.9", os: "ubuntu-latest", session: "size" }
 
     env:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.8"
+    python: "3.9"
   jobs:
     post_create_environment:
       # Install poetry

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.9"
+    python: "3.9" # should keep this in sync with version in dev-env.yml
   jobs:
     post_create_environment:
       # Install poetry

--- a/dev-env.yml
+++ b/dev-env.yml
@@ -3,9 +3,9 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - conda-forge::python=3.9 # the lowest version of python that we formally support; keep in sync with release.yml and noxfile.py
+  - conda-forge::python=3.9 # the lowest version of python that we formally support; keep in sync with release.yml, tests.yml, .readthedocs.yaml, and noxfile.py
   - conda-forge::pip==24.3.1
-  - conda-forge::poetry==1.8.5
+  - conda-forge::poetry==1.8.5 # should keep this in sync with version in release.yml
   - conda-forge::nox==2024.10.9
   - conda-forge::poetry-plugin-export==1.8.0
   - pip:

--- a/dev-env.yml
+++ b/dev-env.yml
@@ -3,11 +3,11 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - conda-forge::python=3.8 # the lowest version of python that we formally support; keep in sync with release.yml
-  - conda-forge::pip==24.0
-  - conda-forge::poetry==1.8.3 # should keep this in sync with version in release.yml
-  - conda-forge::nox==2024.4.15
+  - conda-forge::python=3.9 # the lowest version of python that we formally support; keep in sync with release.yml and noxfile.py
+  - conda-forge::pip==24.3.1
+  - conda-forge::poetry==1.8.5
+  - conda-forge::nox==2024.10.19
   - conda-forge::poetry-plugin-export==1.8.0
   - pip:
     - nox-poetry==1.0.3
-    - poetry-conda==0.1.1
+    - poetry-conda==0.1.3

--- a/dev-env.yml
+++ b/dev-env.yml
@@ -6,7 +6,7 @@ dependencies:
   - conda-forge::python=3.9 # the lowest version of python that we formally support; keep in sync with release.yml and noxfile.py
   - conda-forge::pip==24.3.1
   - conda-forge::poetry==1.8.5
-  - conda-forge::nox==2024.10.19
+  - conda-forge::nox==2024.10.9
   - conda-forge::poetry-plugin-export==1.8.0
   - pip:
     - nox-poetry==1.0.3

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ from nox_poetry import session  # type: ignore
 
 package = "haptools"
 python_versions = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-locked_python_version = "3.8"
+locked_python_version = "3.9" # keep in sync with dev-env.yml
 nox.needs_version = ">= 2022.11.21"
 nox.options.sessions = (
     "docs",

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ from nox_poetry import session  # type: ignore
 
 package = "haptools"
 python_versions = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-locked_python_version = "3.9" # keep in sync with dev-env.yml
+locked_python_version = "3.9"  # keep in sync with dev-env.yml
 nox.needs_version = ">= 2022.11.21"
 nox.options.sessions = (
     "docs",


### PR DESCRIPTION
We are officially deprecating support for py 3.8, since it is [end-of-life](https://devguide.python.org/versions/). We will support py 3.8 _unofficially_ by continuing to test our code against it in our CI, and users will still be able to install new versions of haptools with python 3.8

However, we can no longer make guarantees that future PRs will not unexpectedly drop support for py 3.8 one day, since we will be developing haptools with py 3.9 from now on. All tools that depend upon haptools should upgrade their minimum python version to 3.9