### PR TITLE
feat: use chunking when reading from PGENs in `simgenotype`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
           - { python: "3.10", os: "ubuntu-latest", session: "tests" }
           - { python: "3.11", os: "ubuntu-latest", session: "tests" }
           - { python: "3.12", os: "ubuntu-latest", session: "tests" }
-          - { python: "3.13", os: "ubuntu-latest", session: "tests" }
+          # - { python: "3.13", os: "ubuntu-latest", session: "tests" }
           # - { python: "3.11", os: "windows-latest", session: "tests" }
           - { python: "3.9", os: "macos-13", session: "tests" }
           - { python: "3.12", os: "macos-latest", session: "tests" }

--- a/haptools/sim_genotype.py
+++ b/haptools/sim_genotype.py
@@ -104,7 +104,7 @@ def output_vcf(
     #      IE sample HG00097 is index 1 in a list of samples [HG00096 HG00097 HG00098]
     # create sample dictionary that holds sample name to the index in the vcf file for quick access 
     if variant_file.endswith(".pgen"):
-        vcf = GenotypesPLINK(variant_file, log=log)
+        vcf = GenotypesPLINK(variant_file, chunk_size=chunk_size, log=log)
     else:
         vcf = GenotypesVCF(variant_file, log=log)
     

--- a/noxfile.py
+++ b/noxfile.py
@@ -64,9 +64,9 @@ if os.getenv("CONDA_EXE"):
         session.conda_install(
             "coverage[toml]",
             "pytest",
-            "pysam", # temp: until https://github.com/pysam-developers/pysam/issues/1230#issuecomment-2445293633
             channel="conda-forge",
         )
+        session.conda_install("pysam", channel="bioconda") # temp: until https://github.com/pysam-developers/pysam/issues/1230#issuecomment-2445293633
         install_handle_python_numpy(session)
         try:
             session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -64,7 +64,6 @@ if os.getenv("CONDA_EXE"):
         session.conda_install(
             "coverage[toml]",
             "pytest",
-            "numpy>=1.20.0",
             channel="conda-forge",
         )
         install_handle_python_numpy(session)

--- a/noxfile.py
+++ b/noxfile.py
@@ -66,7 +66,6 @@ if os.getenv("CONDA_EXE"):
             "pytest",
             channel="conda-forge",
         )
-        session.conda_install("pysam", channel="bioconda") # temp: until https://github.com/pysam-developers/pysam/issues/1230#issuecomment-2445293633
         install_handle_python_numpy(session)
         try:
             session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -64,6 +64,7 @@ if os.getenv("CONDA_EXE"):
         session.conda_install(
             "coverage[toml]",
             "pytest",
+            "pysam", # temp: until https://github.com/pysam-developers/pysam/issues/1230#issuecomment-2445293633
             channel="conda-forge",
         )
         install_handle_python_numpy(session)


### PR DESCRIPTION
resolves https://github.com/CAST-genomics/haptools/issues/267#issuecomment-2631115628

Until now, we only use chunking to write PGEN files from `simgenotype` -- not to load from them. This PR uses the same chunk size for both. I could also add a new parameter if we want the loading to use a different chunk size than the writing.