### PR TITLE
feat: use less memory when obtaining a count of the number of variants

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -522,6 +522,12 @@ class TestGenotypesPLINK:
         np.testing.assert_allclose(gts.data, expected_data)
         assert gts.samples == tuple(samples)
 
+        gts = GenotypesPLINK(DATADIR / "simple.pgen")
+        gts.read(samples=samples_set, variants=variants)
+        gts.check_phase()
+        np.testing.assert_allclose(gts.data, expected_data)
+        assert gts.samples == tuple(samples)
+
     def test_write_genotypes_chunked(self):
         gts = self._get_fake_genotypes_plink()
 


### PR DESCRIPTION
This PR reduces the memory usage of GenotypesPLINK when it is provided with a region parameter.

Prior to this, it would first allocate enough memory for _all_ of the variants in the PVAR file, read the variants in the specified region from the PVAR file, and then discard any memory that it didn't use. I did this because I didn't have a way of knowing how many variants we would have in the PVAR file within the specified region, so I just used the total number of variants in the PVAR file as an initial upper bound. But this turned out to require _a lot_ of memory for really large PVAR files.

The new code first tries to determine the number of variants in the PVAR file within the specified region. And then it allocates memory for them and parses them, in a second pass.